### PR TITLE
fix: rtti screen scrolling

### DIFF
--- a/LiveINI/main.cpp
+++ b/LiveINI/main.cpp
@@ -167,10 +167,10 @@ int WinMain(HINSTANCE, HINSTANCE, LPSTR, int)
 				scan_window_draw();
 				ImGui::EndTabItem();
 			}
-                        if (ImGui::BeginTabItem("RTTI")) {
-                                draw_rtti_window();
-                                ImGui::EndTabItem();
-                        }
+            if (ImGui::BeginTabItem("RTTI")) {
+                draw_rtti_window();
+                ImGui::EndTabItem();
+            }
 			ImGui::EndTabBar();
 		}
 	}

--- a/LiveINI/rtti_window.cpp
+++ b/LiveINI/rtti_window.cpp
@@ -72,6 +72,8 @@ void draw_rtti_window() {
         auto result_count = std::distance(match_begin, match_end);
         ImGui::Text("Results: %d / %d", result_count, rtti.size());
 
+        ImGui::BeginChild("rtti_results_section", ImVec2{}, false, ImGuiWindowFlags_NoScrollbar);
+
         ImGuiListClipper clip{};
         clip.Begin(result_count, ImGui::GetTextLineHeightWithSpacing());
         while (clip.Step()) {
@@ -91,4 +93,5 @@ void draw_rtti_window() {
                         ImGui::PopID();
                 }
         }
+        ImGui::EndChild();
 }


### PR DESCRIPTION
add results in rtti screen to imgui child, so that scrolling does not touch the header buttons